### PR TITLE
Add simple AI pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
 REACT_APP_API_BASE_URL=http://localhost:5000
+OPENAI_API_KEY=sk-your-key
+KNOWLEDGE_SERVICE_URL=http://localhost:5002
+AI_SERVICE_URL=http://localhost:5003

--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@
 
 1. **初始化前端**：进入 `frontend` 目录，运行 `npm install` 安装依赖。开发环境可以使用 `npm start` 启动本地服务器，默认监听 `http://localhost:3000`。
 2. **初始化后端**：进入 `backend/src`，使用 `dotnet` 命令创建或还原项目所需的依赖。此仓库中的 `.csproj` 文件引用了 ABP VNext 包，需要在安装好 .NET SDK 和配置好 nuget 源后再执行 `dotnet restore`、`dotnet build`。
-3. **配置环境**：根据您的实际部署环境配置数据库连接、OpenAI API Key、向量数据库等。在根目录可复制 `.env.example` 为 `.env` 并修改 `REACT_APP_API_BASE_URL`，供前端读取后端地址。在生产环境中建议使用 Docker Compose 或 Kubernetes 进行部署，并配置 HTTPS、身份认证等安全设置。
+3. **配置环境**：根据您的实际部署环境配置数据库连接、OpenAI API Key、向量数据库等。在根目录可复制 `.env.example` 为 `.env` 并修改 `REACT_APP_API_BASE_URL`，供前端读取后端地址。后端运行时需要设置以下环境变量：
+
+   - `OPENAI_API_KEY`：调用 OpenAI 接口所需的 API Key。
+   - `KNOWLEDGE_SERVICE_URL`：ChatService 访问 KnowledgeService 的地址，默认 `http://localhost:5002`。
+   - `AI_SERVICE_URL`：ChatService 访问 AIIntegrationService 的地址，默认 `http://localhost:5003`。
+
+   在生产环境中建议使用 Docker Compose 或 Kubernetes 进行部署，并配置 HTTPS、身份认证等安全设置。
 
 欢迎根据业务需求对代码结构和逻辑进行扩展和修改。
 

--- a/backend/src/SmartAI.AIIntegrationService/Controllers/AIController.cs
+++ b/backend/src/SmartAI.AIIntegrationService/Controllers/AIController.cs
@@ -1,6 +1,12 @@
 using Microsoft.AspNetCore.Mvc;
 using Volo.Abp.AspNetCore.Mvc;
 using System.Threading.Tasks;
+using System.Text.Json;
+using System.Text;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace SmartAI.AIIntegrationService.Controllers
 {
@@ -17,17 +23,61 @@ namespace SmartAI.AIIntegrationService.Controllers
         /// 调用 LLM 的示例接口。请求包含用户输入和检索的文档信息。
         /// </summary>
         /// <param name="request">生成请求</param>
-        [HttpPost("generate")] 
+        [HttpPost("generate")]
         public async Task<IActionResult> Generate([FromBody] GenerateRequest request)
         {
             if (request == null || string.IsNullOrWhiteSpace(request.Prompt))
             {
                 return BadRequest(new { error = "prompt cannot be empty" });
             }
-            // TODO: 实际调用 LLM，例如通过 OpenAI API
-            var content = $"这是针对您的提示生成的示例回答: {request.Prompt}";
-            await Task.CompletedTask;
-            return Ok(new { content });
+
+            var apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                return StatusCode(500, new { error = "OPENAI_API_KEY not configured" });
+            }
+
+            var docs = request.Documents != null ? string.Join("\n", request.Documents) : string.Empty;
+
+            var payload = new
+            {
+                model = "gpt-3.5-turbo",
+                messages = new object[]
+                {
+                    new { role = "system", content = $"参考文档: {docs}" },
+                    new { role = "user", content = request.Prompt }
+                }
+            };
+
+            using var http = new HttpClient();
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+            var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+            var resp = await http.PostAsync("https://api.openai.com/v1/chat/completions", content);
+            var respJson = await resp.Content.ReadAsStringAsync();
+            if (!resp.IsSuccessStatusCode)
+            {
+                return StatusCode((int)resp.StatusCode, respJson);
+            }
+
+            var result = JsonSerializer.Deserialize<OpenAIResponse>(respJson, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            var answer = result?.Choices?.FirstOrDefault()?.Message?.Content ?? string.Empty;
+            return Ok(new { content = answer });
+        }
+
+        public class OpenAIResponse
+        {
+            public List<Choice>? Choices { get; set; }
+        }
+
+        public class Choice
+        {
+            public Message? Message { get; set; }
+        }
+
+        public class Message
+        {
+            public string? Content { get; set; }
         }
 
         public class GenerateRequest

--- a/backend/src/SmartAI.ChatService/Controllers/ChatController.cs
+++ b/backend/src/SmartAI.ChatService/Controllers/ChatController.cs
@@ -1,6 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
 using Volo.Abp.AspNetCore.Mvc;
 using System.Threading.Tasks;
+using System.Text.Json;
+using System.Text;
+using System.Net.Http;
+using System.Collections.Generic;
 
 namespace SmartAI.ChatService.Controllers
 {
@@ -17,17 +21,60 @@ namespace SmartAI.ChatService.Controllers
         /// 简单的问答接口示例。实际实现应根据用户问题调用 KnowledgeService 和 AIIntegrationService。
         /// </summary>
         /// <param name="request">包含用户问题的请求对象。</param>
-        [HttpPost("ask")] 
+        [HttpPost("ask")]
         public async Task<IActionResult> Ask([FromBody] AskRequest request)
         {
             if (request == null || string.IsNullOrWhiteSpace(request.Question))
             {
                 return BadRequest(new { error = "question cannot be empty" });
             }
-            // TODO: 调用 KnowledgeService 和 AIIntegrationService 返回真实答案
-            var answer = $"您问的是: {request.Question}. 目前仅返回示例答案。";
-            await Task.CompletedTask;
+
+            var knowledgeUrl = Environment.GetEnvironmentVariable("KNOWLEDGE_SERVICE_URL") ?? "http://localhost:5002";
+            var aiUrl = Environment.GetEnvironmentVariable("AI_SERVICE_URL") ?? "http://localhost:5003";
+
+            using var http = new HttpClient();
+
+            // 调用 KnowledgeService 获取相关文档
+            var searchResp = await http.GetAsync($"{knowledgeUrl}/api/knowledge/search?query={Uri.EscapeDataString(request.Question)}");
+            var searchJson = await searchResp.Content.ReadAsStringAsync();
+            var search = JsonSerializer.Deserialize<SearchResult>(searchJson, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            var docs = new List<string>();
+            if (search?.Items != null)
+            {
+                foreach (var item in search.Items)
+                {
+                    if (!string.IsNullOrWhiteSpace(item.Snippet))
+                    {
+                        docs.Add(item.Snippet);
+                    }
+                }
+            }
+
+            // 调用 AIIntegrationService 生成回答
+            var aiRequest = new AIRequest { Prompt = request.Question, Documents = docs };
+            var aiContent = new StringContent(JsonSerializer.Serialize(aiRequest), Encoding.UTF8, "application/json");
+            var aiResp = await http.PostAsync($"{aiUrl}/api/ai/generate", aiContent);
+            var aiJson = await aiResp.Content.ReadAsStringAsync();
+            var ai = JsonSerializer.Deserialize<AIResponse>(aiJson, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            var answer = ai?.Content ?? string.Empty;
             return Ok(new { answer });
+        }
+
+        public class SearchResult
+        {
+            public List<SearchItem>? Items { get; set; }
+        }
+
+        public class SearchItem
+        {
+            public string? Snippet { get; set; }
+        }
+
+        public class AIResponse
+        {
+            public string? Content { get; set; }
         }
 
         public class AskRequest


### PR DESCRIPTION
## Summary
- add environment variable sample values
- describe environment variables for the AI services in README
- extend ChatService to call KnowledgeService and AIIntegrationService
- implement OpenAI call in AIIntegrationService

## Testing
- `npm test --silent --no-watch --no-progress`
- `dotnet build backend/src/SmartAI.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b67d1a9e0832a9af009bfc9b3af58